### PR TITLE
LWP https module deps for condensed SDRF script and bump version.

### DIFF
--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ## perl version
- perl_version=$(perl -e 'print $^V');
- perl_version=${perl_version:1}
+perl_version=$(perl -e 'print $^V');
+perl_version=${perl_version:1}
 
 ## Hack to get around hardcoded paths in perl modules and config requirements
 atlasprodDir=${PREFIX}/atlasprod
@@ -11,12 +11,12 @@ cp -r $SRC_DIR/perl_modules $atlasprodDir
 cp -r $SRC_DIR/supporting_files $atlasprodDir
 chmod -R a+x $atlasprodDir
 
- # Path to installed perl libs from CPAN
- PERLLIB="${PREFIX}/lib/perl5/${perl_version}/perl_lib"
- mkdir -p $PERLLIB && chmod a+x $PERLLIB
+# Path to installed perl libs from CPAN
+PERLLIB="${PREFIX}/lib/perl5/${perl_version}/perl_lib"
+mkdir -p $PERLLIB && chmod a+x $PERLLIB
 
- ## install modules from CPAN directly as they are no conda packages for these modules
- cpanm -l $PERLLIB MooseX::FollowPBP \
+## install modules from CPAN directly as they are no conda packages for these modules
+cpanm -l $PERLLIB MooseX::FollowPBP \
  					URI::Escape \
  					URL::Encode \
  					Config::YAML \

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -15,8 +15,6 @@ chmod -R a+x $atlasprodDir
  PERLLIB="${PREFIX}/lib/perl5/${perl_version}/perl_lib"
  mkdir -p $PERLLIB && chmod a+x $PERLLIB
 
- ## Text CSV XS first for BioMagetab
- cpanm -l $PERLLIB Text::CSV_XS@0.32
  ## install modules from CPAN directly as they are no conda packages for these modules
  cpanm -l $PERLLIB MooseX::FollowPBP \
  					URI::Escape \

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## perl version 
+## perl version
  perl_version=$(perl -e 'print $^V');
  perl_version=${perl_version:1}
 
@@ -14,7 +14,9 @@ chmod -R a+x $atlasprodDir
  # Path to installed perl libs from CPAN
  PERLLIB="${PREFIX}/lib/perl5/${perl_version}/perl_lib"
  mkdir -p $PERLLIB && chmod a+x $PERLLIB
- 
+
+ ## Text CSV XS first for BioMagetab
+ cpanm -l $PERLLIB Text::CSV_XS@0.32
  ## install modules from CPAN directly as they are no conda packages for these modules
  cpanm -l $PERLLIB MooseX::FollowPBP \
  					URI::Escape \

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -55,6 +55,7 @@ requirements:
   run:
     - perl =5.26.2
     - perl-moose
+    - perl-lwp-protocol-https
     - perl-log-log4perl
     - perl-list-util
     - perl-list-moreutils

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -16,35 +16,34 @@ build:
 requirements:
   build:
    - perl =5.26.2
-   - perl-list-util
-   - perl-list-moreutils
-   - perl-moose
-   - perl-log-log4perl
-   - perl-app-cpanminus
-   - perl-path-tiny
-   - perl-json-parse
-   - perl-data-dumper
    - perl-array-compare
-   - perl-lwp-simple
-   - perl-datetime
-   - perl-xml-simple
-   - perl-tie-ixhash
-   - perl-readonly
-   - perl-carp
+   - perl-app-cpanminus
    - perl-base
-   - perl-file-spec
+   - perl-carp
+   - perl-data-dumper
+   - perl-data-compare
+   - perl-datetime
+   - perl-datetime-format-strptime
+   - perl-date-format
    - perl-dbi
    - perl-dbd-pg
-   - perl-datetime-format-strptime
+   - perl-json-parse
+   - perl-list-util
+   - perl-list-moreutils
+   - perl-log-log4perl
+   - perl-lwp-simple
+   - perl-lwp-protocol-https
+   - perl-moose
+   - perl-path-tiny
+   - perl-tie-ixhash
+   - perl-readonly
+   - perl-file-spec
    - perl-text-csv
    - perl-json
    - perl-xml-simple
    - perl-xml-parser
    - perl-xml-writer
    - perl-ipc-cmd
-   - perl-datetime
-   - perl-data-compare
-   - perl-lwp-protocol-https
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
 

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.3" %}
+{% set version = "0.1.2" %}
 
 package:
   name: perl-atlas-modules
@@ -11,7 +11,7 @@ source:
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 
 package:
   name: perl-atlas-modules
   version: {{ version }}
 
 source:
-  url: https://github.com/ebi-gene-expression-group/perl-atlas-modules/archive/{{ version }}.tar.gz  
+  url: https://github.com/ebi-gene-expression-group/perl-atlas-modules/archive/{{ version }}.tar.gz
   sha256: f1a63297c8325f750221977166ddb208e3a4073557245c1cfdb72b0941d31cb2
 
 # If this is a new build for the same version, increment the build
@@ -44,6 +44,7 @@ requirements:
    - perl-ipc-cmd
    - perl-datetime
    - perl-data-compare
+   - perl-lwp-protocol-https
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
 
@@ -105,7 +106,7 @@ test:
 about:
   home: https://github.com/ebi-gene-expression-group/perl-atlas-modules
   license: GPL-3
-  summary: A package exporting in-house perl functions and classes used in the data production of EMBL-EBI Expression Atlas data. 
+  summary: A package exporting in-house perl functions and classes used in the data production of EMBL-EBI Expression Atlas data.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Condensed SDRF script failed due to lack of support for HTTPS, which required LWP HTTPS module. Bumped the build of the package.