### PR TITLE
Added experiment_metadata repo

### DIFF
--- a/recipes/atlas-experiment-metadata/build.sh
+++ b/recipes/atlas-experiment-metadata/build.sh
@@ -1,0 +1,7 @@
+mkdir -p $PREFIX/bin
+cp *.sh $PREFIX/bin
+cp *.pl $PREFIX/bin
+cp *.txt $PREFIX/bin
+cp *.properties $PREFIX/bin
+
+

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "0.0.1" %}
+
+package:
+  name: atlas-experiment-metadata
+  version: {{ version }}
+
+source:
+    url: https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz
+    sha256: 46647363399be34b4bb97d77af298b573bb7a6fdc9d0c487d0db3b7802cc68d5
+
+build:
+  number: 0
+
+requirements:
+  build:
+  host:
+  run:
+    - bash
+    - perl-atlas-modules
+
+test:
+  commands:
+    - condense_sdrf.pl | grep "You must specify an experiment accession" 2> /dev/null
+    - which single_cell_condensed_sdrf.sh
+
+about:
+  home: https://github.com/ebi-gene-expression-group/experiment_metadata
+  summary: Metadata handling scripts for Atlas
+  license: Apache-2.0
+  license_family: Apache
+
+extra:
+  recipe-maintainers:
+    - pinin4fjords

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 
 package:
   name: atlas-experiment-metadata
@@ -6,7 +6,7 @@ package:
 
 source:
     url: https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz
-    sha256: 46647363399be34b4bb97d77af298b573bb7a6fdc9d0c487d0db3b7802cc68d5
+    sha256: e459603e732faac6cfb7959de10bdcb8305c365b467ff559fc8ef28ae0aa7623
 
 build:
   number: 0
@@ -16,12 +16,17 @@ requirements:
   host:
   run:
     - bash
+    - libgfortran
     - perl-atlas-modules
+    - r-optparse=1.6.0
+    - r-reshape2 
+    - r-data.table
 
 test:
   commands:
     - condense_sdrf.pl | grep "You must specify an experiment accession" 2> /dev/null
     - which single_cell_condensed_sdrf.sh
+    - unmelt_condensed.R --help
 
 about:
   home: https://github.com/ebi-gene-expression-group/experiment_metadata


### PR DESCRIPTION
Added a recipe for scripts in the newly factored-out experiment_metadata repo. To be used in workflows needing e.g. condensed SDRF generation (once I've managed to allow script execution without extensive dependence on environment).

Have checked that the build works, and have uploaded the package to our Anaconda space.