### PR TITLE
Dependencies and templating for magetab validation needs.

### DIFF
--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -21,7 +21,9 @@ cpanm -l $PERLLIB MooseX::FollowPBP \
  					URL::Encode \
  					Config::YAML \
  					File::Basename \
- 					Bio::MAGETAB
+ 					Bio::MAGETAB \
+					Date::Parse \
+					Log::Dispatch::File
 
 mkdir -p ${PREFIX}/etc/conda/activate.d/
 echo "export export PERL5LIB=$PERL5LIB:$atlasprodDir/perl_modules:$PERLLIB/lib/perl5" > ${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}.sh

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -23,6 +23,8 @@ cpanm -l $PERLLIB MooseX::FollowPBP \
  					File::Basename \
  					Bio::MAGETAB \
 					Date::Parse \
+					Test::MockObject \
+					Text::TabularDisplay \
 					Log::Dispatch::File
 
 mkdir -p ${PREFIX}/etc/conda/activate.d/

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -11,7 +11,7 @@ source:
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 0
+  number: 2
 
 requirements:
   build:
@@ -54,6 +54,8 @@ requirements:
 
   run:
     - perl =5.26.2
+    - perl-array-utils
+    - perl-class-std
     - perl-moose
     - perl-lwp-protocol-https
     - perl-log-log4perl

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 
 package:
   name: perl-atlas-modules
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/perl-atlas-modules/archive/{{ version }}.tar.gz
-  sha256: f1a63297c8325f750221977166ddb208e3a4073557245c1cfdb72b0941d31cb2
+  sha256: cd05e345eac80bf02a82f3043876685eecab8b33a458474e66962e9e44dbb133
 
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/perl-atlas-modules/post-link.sh
+++ b/recipes/perl-atlas-modules/post-link.sh
@@ -1,0 +1,3 @@
+atlasprodDir=${PREFIX}/atlasprod
+
+sed -i.bak "s+<CONDA_PREFIX>+${PREFIX}+g" $atlasprodDir/supporting_files/AtlasSiteConfig.yml


### PR DESCRIPTION
This PR adds changes on the perl-atlas-modules to allow downstream execution of curator's perl scripts (in particular validate_magetab). This includes additional perl dependencies and the specification of the Atlas site config file post installation to point to real paths inside the conda environment. This is a first approach for providing default config files within the conda installation, which will be improved in the future through the injection of env variables to define the main config path.