### PR TITLE
Add gene annotation manipulation CLI package

### DIFF
--- a/recipes/atlas-gene-annotation-manipulation/build.sh
+++ b/recipes/atlas-gene-annotation-manipulation/build.sh
@@ -1,0 +1,2 @@
+mkdir -p $PREFIX/bin
+cp *.sh *.R $PREFIX/bin

--- a/recipes/atlas-gene-annotation-manipulation/meta.yaml
+++ b/recipes/atlas-gene-annotation-manipulation/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "0.0.1" %}
+
+package:
+  name: atlas-gene-annotation-manipulation
+  version: {{ version }}
+
+source:
+  url: https://github.com/ebi-gene-expression-group/atlas-gene-annotation-manipulation/archive/v{{ version }}.tar.gz
+  sha256: 3f27d93514967b46e16d193511cbceff7d439baf8b7424b131244d27639b7eba 
+
+build:
+  number: 0
+
+requirements:
+  build:
+  host:
+  run:
+    - r-base
+    - r-optparse
+    - bioconductor-rtracklayer
+    - bioconductor-biostrings
+
+test:
+  commands:
+    - gtf2featureAnnotation.R -h 
+
+about:
+  home: https://github.com/ebi-gene-expression-group/atlas-gene-annotation-manipulation 
+  license: Apache-2.0
+  summary: Scripts for manipulating gene annotation 
+  license_family: Apache
+


### PR DESCRIPTION
finally added a conda package for this script, which I've used in various forms in multiple places. Those places can now be switched to use this.

https://github.com/ebi-gene-expression-group/atlas-gene-annotation-manipulation