### PR TITLE
Remove samtools and openssl from irap-components (provided by irap-bamutils)

### DIFF
--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bf3d0a35ffba3076465da9f6a7dc513ea2110f0708edd1640e659366ed304614 
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win32]
 
 requirements:
@@ -21,8 +21,6 @@ requirements:
         - r-optparse
         - r-data.table
         - fastq_utils
-        - samtools =1.9
-        - openssl=1.0
         - irap-bamutils
 
 test:


### PR DESCRIPTION
This enables the build process to work on macOS, otherwise we get dependency conflicts for some reason. Both packages are provided anyway by irap-bamutils.