### PR TITLE
Adds r-interval to irap-components

### DIFF
--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: bf3d0a35ffba3076465da9f6a7dc513ea2110f0708edd1640e659366ed304614 
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win32]
 
 requirements:
@@ -20,6 +20,7 @@ requirements:
         - make
         - r-optparse
         - r-data.table
+        - r-intervals
         - fastq_utils
         - irap-bamutils
 


### PR DESCRIPTION
This adds r-intervals to circumvent:

```
[INFO 09/07-09:41] Loading gtf file test-data/aerial_and_root//Arabidopsis_thaliana.TAIR10.44.gtf complete.
Time taken:  26.70417  s
[INFO 09/07-09:41] seqid
 [INFO 09/07-09:41] source
 [INFO 09/07-09:41] feature
 [INFO 09/07-09:41] start
 [INFO 09/07-09:41] end
 [INFO 09/07-09:41] score
 [INFO 09/07-09:41] strand
 [INFO 09/07-09:41] frame
 [INFO 09/07-09:41] gene_id
 [INFO 09/07-09:41] transcript_id
 [INFO 09/07-09:41] exon_number
 [INFO 09/07-09:41] gene_biotype
 [INFO 09/07-09:41] exon_id
 [INFO 09/07-09:41] biotype
[INFO 09/07-09:41] Read 313952 rows from test-data/aerial_and_root//Arabidopsis_thaliana.TAIR10.44.gtf

[INFO 09/07-09:41] Using 313952 exons
[INFO 09/07-09:41] Computing length of genes...
Error in library("intervals") : there is no package called ‘intervals’
Calls: get.gene.length.from.gtf ... suppressPackageStartupMessages -> withCallingHandlers -> library
Execution halted
```