### PR TITLE
Fixes for perl module package

### DIFF
--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -1,22 +1,28 @@
 #!/bin/bash
 
-## perl version
-perl_version=$(perl -e 'print $^V');
-perl_version=${perl_version:1}
-
-
 ## Hack to get around hardcoded paths in perl modules and config requirements
 atlasprodDir=${PREFIX}/atlasprod
 mkdir -p $atlasprodDir
 cp -r $SRC_DIR/perl_modules $atlasprodDir
 cp -r $SRC_DIR/supporting_files $atlasprodDir
-chmod -R a+x $atlasprodDir
 
 # Path to installed perl libs from CPAN
+
+## perl version
+perl_version=$(perl -e 'print $^V');
+perl_version=${perl_version:1}
+
 PERLLIB="${PREFIX}/lib/perl5/${perl_version}/perl_lib"
-mkdir -p $PERLLIB && chmod a+x $PERLLIB
+mkdir -p $PERLLIB 
 
 ## install modules from CPAN directly as they are no conda packages for these modules
+
+# A little hack to try to nudge Bioconda MacOS CI- which seems to have HOME set
+# to 'UNKNOWN' which disrupts cpanm
+
+if [[ ${HOST} =~ .*darwin.* ]]; then
+    export HOME=/Users/distiller
+fi
 
 cpanm -l $PERLLIB MooseX::FollowPBP \
                     URI::Escape \
@@ -33,8 +39,3 @@ cpanm -l $PERLLIB MooseX::FollowPBP \
 
 mkdir -p ${PREFIX}/etc/conda/activate.d/
 echo "export PERL5LIB=$PERL5LIB:$atlasprodDir/perl_modules:$PERLLIB/lib/perl5" > ${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}.sh
-
-chmod u+x ${PREFIX}/lib/${perl_version}/*
-
-# See https://docs.conda.io/projects/conda-build
-# for a list of environment variables that are set during the build process.

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -19,15 +19,17 @@ mkdir -p $PERLLIB && chmod a+x $PERLLIB
 ## install modules from CPAN directly as they are no conda packages for these modules
 
 cpanm -l $PERLLIB MooseX::FollowPBP \
- 					URI::Escape \
- 					URL::Encode \
- 					Config::YAML \
- 					File::Basename \
- 					Bio::MAGETAB \
-					Date::Parse \
-					Test::MockObject \
-					Text::TabularDisplay \
-					Log::Dispatch::File
+                    URI::Escape \
+                    URL::Encode \
+                    Config::YAML \
+                    File::Basename \
+                    Bio::MAGETAB \
+                    Date::Parse \
+                    Test::MockObject \
+                    Text::TabularDisplay \
+                    Log::Dispatch::File \
+                    IO::CaptureOutput \
+                    Class::DBI
 
 mkdir -p ${PREFIX}/etc/conda/activate.d/
 echo "export export PERL5LIB=$PERL5LIB:$atlasprodDir/perl_modules:$PERLLIB/lib/perl5" > ${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}.sh

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+echo "PREFIX: $PREFIX" 1>&2
+
 ## perl version
 perl_version=$(perl -e 'print $^V');
 perl_version=${perl_version:1}
+
 
 ## Hack to get around hardcoded paths in perl modules and config requirements
 atlasprodDir=${PREFIX}/atlasprod
@@ -16,6 +19,7 @@ PERLLIB="${PREFIX}/lib/perl5/${perl_version}/perl_lib"
 mkdir -p $PERLLIB && chmod a+x $PERLLIB
 
 ## install modules from CPAN directly as they are no conda packages for these modules
+
 cpanm -l $PERLLIB MooseX::FollowPBP \
  					URI::Escape \
  					URL::Encode \

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -32,7 +32,7 @@ cpanm -l $PERLLIB MooseX::FollowPBP \
                     Class::DBI
 
 mkdir -p ${PREFIX}/etc/conda/activate.d/
-echo "export export PERL5LIB=$PERL5LIB:$atlasprodDir/perl_modules:$PERLLIB/lib/perl5" > ${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}.sh
+echo "export PERL5LIB=$PERL5LIB:$atlasprodDir/perl_modules:$PERLLIB/lib/perl5" > ${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}.sh
 
 chmod u+x ${PREFIX}/lib/${perl_version}/*
 

--- a/recipes/perl-atlas-modules/build.sh
+++ b/recipes/perl-atlas-modules/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "PREFIX: $PREFIX" 1>&2
-
 ## perl version
 perl_version=$(perl -e 'print $^V');
 perl_version=${perl_version:1}

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -166,5 +166,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - suhaibMo
+    - pinin4fjords
 

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.4" %}
+{% set version = "0.1.5" %}
 
 package:
   name: perl-atlas-modules
@@ -6,21 +6,23 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/perl-atlas-modules/archive/{{ version }}.tar.gz
-  sha256: cd05e345eac80bf02a82f3043876685eecab8b33a458474e66962e9e44dbb133
+  sha256: df81a9327e1f6028eaa84e7ff31ca4900d0e468e0d96e2f367278043941853e0
 
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 4
+  number: 0
 
 requirements:
   build:
    - perl-algorithm-diff
    - perl-app-cpanminus
-   - perl-array-compare
+   - perl-archive-extract
+   - perl-array-compare 
    - perl-base
    - perl-carp
    - perl-carp-clan
+   - perl-clone
    - perl-data-compare
    - perl-data-dumper
    - perl-date-format
@@ -44,6 +46,7 @@ requirements:
    - perl-lwp-protocol-https
    - perl-lwp-simple
    - perl-mailtools
+   - perl-mime-lite
    - perl-module-build
    - perl-module-build-tiny
    - perl-module-pluggable
@@ -77,16 +80,18 @@ requirements:
    - {{ compiler('cxx') }}
 
   host:
-   - perl =5.26.2
+   - perl=5.26.2
 
   run:
    - perl-algorithm-diff
    - perl-array-compare
+   - perl-archive-extract
    - perl-array-utils
    - perl-base
    - perl-carp
    - perl-carp-clan
    - perl-class-std
+   - perl-clone
    - perl-data-compare
    - perl-data-dumper
    - perl-date-format
@@ -110,6 +115,7 @@ requirements:
    - perl-lwp-protocol-https
    - perl-lwp-simple
    - perl-mailtools
+   - perl-mime-lite
    - perl-module-build
    - perl-module-build-tiny
    - perl-module-pluggable

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.5" %}
+{% set version = "0.1.6" %}
 
 package:
   name: perl-atlas-modules
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/perl-atlas-modules/archive/{{ version }}.tar.gz
-  sha256: df81a9327e1f6028eaa84e7ff31ca4900d0e468e0d96e2f367278043941853e0
+  sha256: 7b64c50ae92b714275627d10fed0ae653eabd915b2dc85ef19f6c33d637cd762 
 
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
@@ -37,6 +37,8 @@ requirements:
    - perl-extutils-helpers
    - perl-extutils-installpaths
    - perl-file-spec
+   - perl-io-scalar
+   - perl-io-stringy   
    - perl-ipc-cmd
    - perl-json
    - perl-json-parse
@@ -106,6 +108,8 @@ requirements:
    - perl-extutils-helpers
    - perl-extutils-installpaths
    - perl-file-spec
+   - perl-io-scalar
+   - perl-io-stringy   
    - perl-ipc-cmd
    - perl-json
    - perl-json-parse
@@ -164,13 +168,13 @@ test:
     - Atlas::ZoomaClient::MappingResult
     - EBI::FGPT::Config
 
-
 about:
   home: https://github.com/ebi-gene-expression-group/perl-atlas-modules
-  license: GPL-3
+  license: Apache Software License
+  license_family: APACHE
+  license_file: 'LICENSE'
   summary: A package exporting in-house perl functions and classes used in the data production of EMBL-EBI Expression Atlas data.
 
 extra:
   recipe-maintainers:
     - pinin4fjords
-

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.5" %}
+{% set version = "0.1.4" %}
 
 package:
   name: perl-atlas-modules
@@ -11,7 +11,7 @@ source:
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 0
+  number: 4
 
 requirements:
   build:

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.3" %}
+{% set version = "0.1.5" %}
 
 package:
   name: perl-atlas-modules
@@ -11,7 +11,7 @@ source:
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -15,76 +15,130 @@ build:
 
 requirements:
   build:
-   - perl =5.26.2
-   - perl-array-compare
+   - perl-algorithm-diff
    - perl-app-cpanminus
+   - perl-array-compare
    - perl-base
    - perl-carp
-   - perl-data-dumper
+   - perl-carp-clan
    - perl-data-compare
+   - perl-data-dumper
+   - perl-date-format
+   - perl-date-manip
    - perl-datetime
    - perl-datetime-format-strptime
-   - perl-date-format
-   - perl-dbi
    - perl-dbd-pg
-   - perl-json-parse
-   - perl-list-util
-   - perl-list-moreutils
-   - perl-log-log4perl
-   - perl-lwp-simple
-   - perl-lwp-protocol-https
-   - perl-moose
-   - perl-path-tiny
-   - perl-tie-ixhash
-   - perl-readonly
+   - perl-dbi
+   - perl-devel-symdump
+   - perl-extutils-cbuilder
+   - perl-extutils-config
+   - perl-extutils-helpers
+   - perl-extutils-installpaths
    - perl-file-spec
-   - perl-text-csv
-   - perl-json
-   - perl-xml-simple
-   - perl-xml-parser
-   - perl-xml-writer
    - perl-ipc-cmd
+   - perl-json
+   - perl-json-parse
+   - perl-list-moreutils
+   - perl-list-util
+   - perl-log-log4perl
+   - perl-lwp-protocol-https
+   - perl-lwp-simple
+   - perl-mailtools
+   - perl-module-build
+   - perl-module-build-tiny
+   - perl-module-pluggable
+   - perl-moose
+   - perl-moosex-types
+   - perl-params-coerce
+   - perl-params-validate
+   - perl-parse-recdescent
+   - perl-path-tiny
+   - perl-readonly
+   - perl-spiffy
+   - perl-sub-exporter-formethods
+   - perl-sub-uplevel
+   - perl-test-exception
+   - perl-test-inter
+   - perl-test-nowarnings
+   - perl-test-pod
+   - perl-test-pod-coverage
+   - perl-test-warn
+   - perl-text-csv
+   - perl-text-csv_xs
+   - perl-text-diff
+   - perl-tie-ixhash
+   - perl-timedate
+   - perl-uri 
+   - perl-xml-parser
+   - perl-xml-simple
+   - perl-xml-writer
+   - perl-yaml
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
 
-
   host:
    - perl =5.26.2
-   - perl-app-cpanminus
 
   run:
-    - perl =5.26.2
-    - perl-array-utils
-    - perl-class-std
-    - perl-moose
-    - perl-lwp-protocol-https
-    - perl-log-log4perl
-    - perl-list-util
-    - perl-list-moreutils
-    - perl-app-cpanminus
-    - perl-path-tiny
-    - perl-json-parse
-    - perl-data-dumper
-    - perl-array-compare
-    - perl-lwp-simple
-    - perl-datetime
-    - perl-xml-simple
-    - perl-tie-ixhash
-    - perl-readonly
-    - perl-carp
-    - perl-base
-    - perl-file-spec
-    - perl-dbi
-    - perl-dbd-pg
-    - perl-datetime-format-strptime
-    - perl-text-csv
-    - perl-json
-    - perl-xml-simple
-    - perl-xml-parser
-    - perl-xml-writer
-    - perl-ipc-cmd
-    - perl-datetime
-    - perl-data-compare
+   - perl-algorithm-diff
+   - perl-array-compare
+   - perl-array-utils
+   - perl-base
+   - perl-carp
+   - perl-carp-clan
+   - perl-class-std
+   - perl-data-compare
+   - perl-data-dumper
+   - perl-date-format
+   - perl-date-manip
+   - perl-datetime
+   - perl-datetime-format-strptime
+   - perl-dbd-pg
+   - perl-dbi
+   - perl-devel-symdump
+   - perl-extutils-cbuilder
+   - perl-extutils-config
+   - perl-extutils-helpers
+   - perl-extutils-installpaths
+   - perl-file-spec
+   - perl-ipc-cmd
+   - perl-json
+   - perl-json-parse
+   - perl-list-moreutils
+   - perl-list-util
+   - perl-log-log4perl
+   - perl-lwp-protocol-https
+   - perl-lwp-simple
+   - perl-mailtools
+   - perl-module-build
+   - perl-module-build-tiny
+   - perl-module-pluggable
+   - perl-moose
+   - perl-moosex-types
+   - perl-params-coerce
+   - perl-params-validate
+   - perl-parse-recdescent
+   - perl-path-tiny
+   - perl-readonly
+   - perl-spiffy
+   - perl-sub-exporter-formethods
+   - perl-sub-uplevel
+   - perl-test-exception
+   - perl-test-inter
+   - perl-test-nowarnings
+   - perl-test-pod
+   - perl-test-pod-coverage
+   - perl-test-warn
+   - perl-text-csv
+   - perl-text-csv_xs
+   - perl-text-diff
+   - perl-tie-ixhash
+   - perl-timedate
+   - perl-uri 
+   - perl-xml-parser
+   - perl-xml-simple
+   - perl-xml-writer
+   - perl-yaml
 
 test:
   imports:
@@ -113,3 +167,4 @@ about:
 extra:
   recipe-maintainers:
     - suhaibMo
+


### PR DESCRIPTION
This PR does some fixing up of the perl-atlas-modules Conda package:

 - Firstly I've added perl-params-validate Conda dependency (was failing to build from CPAN but works this way). This was all that was needed to get the package to build.

 - Secondly, I've added a bunch more dependencies to the build. The way this package has been set up to work, there are a couple of dependencies that have to come directly from CPAN, and have to be bundled into the package. I've looked at making the recipes for those and there does seem to be some dependency issues that makes it a non-trivial task so we'll have to keep packaging those for now. However a bunch of upstream dependencies for these packages ARE in Bioconda, and by adding those as conda dependencies we minimise the amount we're adding to the package. 

 - I've also bumped the version. The current 0.1.3 was clearly out of date (I can see a 0.1.4 in Anaconda, though only for OSX https://anaconda.org/ebi-gene-expression-group/perl-atlas-modules/files), and I've bumped the build to reflect the changes I've made here.

 - I've flipped the maintainer to myself 