### PR TITLE
Include coexpression and exp designs updater tools on cli

### DIFF
--- a/recipes/atlas-web-bulk-cli/meta.yaml
+++ b/recipes/atlas-web-bulk-cli/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   git_url: https://github.com/ebi-gene-expression-group/atlas-web-bulk
-  git_rev: feature/exp_design_cli
+  git_rev: {{ version }}-cli
 
 
 build:

--- a/recipes/atlas-web-bulk-cli/meta.yaml
+++ b/recipes/atlas-web-bulk-cli/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "36.0.0" %}
+{% set version = "36.1.0" %}
 
 package:
   name: atlas-web-bulk-cli
@@ -6,7 +6,7 @@ package:
 
 source:
   git_url: https://github.com/ebi-gene-expression-group/atlas-web-bulk
-  git_rev: 36.0.0-cli
+  git_rev: feature/exp_design_cli
 
 
 build:


### PR DESCRIPTION
This PR updates the atlas-web-cli conda package to expose cli methods for updating experiment designs and updating coexpressions.