### PR TITLE
Skip no arch on mac and fix web-sc-cli

### DIFF
--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -89,24 +89,33 @@ jobs:
             environment-file: .github/build-environment.yml
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 
-      - name: Derive build dir
-        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
-        id: find-build-dir
-        run: >-
-            subdir=$(conda config --show | grep 'subdir: ' | awk -F': ' '{print $2}');
-            echo "::set-output name=build_dir::$CONDA_PREFIX/conda-bld/$subdir";
-
       - name: Do a test build of modified recipes
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do conda build $recipe; done
 
+      - name: Derive built objects
+        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
+        id: find-built-objects
+        run: |
+            subdirs=$(conda config --show | yq r - 'subdirs' | sed 's/- //' | tr '\n' ' ')
+            packages=""
+            for dir in $subdirs; do
+              for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
+                recipe=$(basename $recipe_dir);
+                if [ -f $CONDA_PREFIX/conda-bld/$dir/$recipe-*.bz2 ]; then
+                  pkg=$(ls ${{ steps.find-build-dir.outputs.build_dir }}/$recipe-*.bz2 | head -n 1)
+                  packages=$packages" "$pkg
+                fi
+              done
+            done
+
+            echo "::set-output name=built_objects::$(echo $packages | xargs)";
+
       - name: Upload to Anaconda
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changed-recipes.outputs.changed_recipes != '' }}
         run: >-
-            for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-                recipe=$(basename $recipe_dir);
-                built_package=$(ls ${{ steps.find-build-dir.outputs.build_dir }}/$recipe-*.bz2 | head -n 1);
-                echo "Found built package $built_package for $recipe"
+            for built_package in ${{ steps.find-built-objects.outputs.built_objects }}; do
+                echo "Found built package $built_package to upload...";
                 anaconda -t ${{ secrets.ANACONDA_TOKEN_ATLAS_CONDA }} upload -u ebi-gene-expression-group $built_package;
             done

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -23,6 +23,9 @@ jobs:
         with:
             fetch-depth: 0
 
+      - name: Install yq - portable yaml processor
+        uses: mikefarah/yq@v4.20.2
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v9.3
@@ -32,8 +35,37 @@ jobs:
       - name: List all modified recipes
         id: changed-recipes
         run: |
-            echo "::set-output name=changed_recipes::$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')"
-     
+            changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
+            changed_no_noarch=""
+            for recipe in $changed; do
+              noarch=$(yq 'build.noarch' $recipe/meta.yaml)
+              if [[ -z "$noarch" ]]; then
+                # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
+                changed_no_noarch=" "+$recipe
+              fi
+            done
+            changed_noarch
+            if [[ "${{ runner.os }}" == "macos-latest" ]]; then
+              changed=$(echo $changed_noarch | xargs) # xarg to remove any trailing spaces.
+            fi
+            echo "::set-output name=changed_recipes::$changed"
+
+      - name: Check directory matches recipe name
+        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
+        run: |
+            status=0
+            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
+              recipe_in_meta=$(yq 'package.name' $recipe/meta.yaml)
+              if [[ "$recipe" != "$recipe_in_meta" ]];
+                echo "Recipe directory is        : $recipe"
+                echo "Recipe name in meta.yaml is: $recipe_in_meta"
+                echo "They should be the same."
+                status=1
+              fi
+            done
+            exit $status
+
+
       - name: Cache conda
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         uses: actions/cache@v2
@@ -51,7 +83,7 @@ jobs:
         with:
             environment-file: .github/build-environment.yml
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
-      
+
       - name: Derive build dir
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         id: find-build-dir
@@ -63,11 +95,11 @@ jobs:
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do conda build $recipe; done
-      
+
       - name: Upload to Anaconda
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changed-recipes.outputs.changed_recipes != '' }}
         run: >-
-            for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do 
+            for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
                 recipe=$(basename $recipe_dir);
                 built_package=$(ls ${{ steps.find-build-dir.outputs.build_dir }}/$recipe-*.bz2 | head -n 1);
                 echo "Found built package $built_package for $recipe"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -42,7 +42,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '^{' $recipe/meta.yaml | yq r - 'build.noarch')
+              noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" "+$recipe
@@ -59,9 +59,10 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '^{' $recipe/meta.yaml | yq r - 'package.name')
-              if [[ "$recipe" != "$recipe_in_meta" ]]; then
-                echo "Recipe directory is        : $recipe"
+              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq r - 'package.name')
+              recipe_dir=$(echo $recipe | sed 's+recipes/++' )
+              if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
+                echo "Recipe directory is        : $recipe_dir"
                 echo "Recipe name in meta.yaml is: $recipe_in_meta"
                 echo "They should be the same."
                 status=1

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -42,7 +42,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '^{' $recipe/meta.yaml | yq r 'build.noarch')
+              noarch=$(grep -v '^{' $recipe/meta.yaml | yq r - 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" "+$recipe
@@ -59,7 +59,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '^{' $recipe/meta.yaml | yq r 'package.name')
+              recipe_in_meta=$(grep -v '^{' $recipe/meta.yaml | yq r - 'package.name')
               if [[ "$recipe" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe"
                 echo "Recipe name in meta.yaml is: $recipe_in_meta"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -24,7 +24,7 @@ jobs:
             fetch-depth: 0
 
       - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.20.2
+        uses: uses: chrisdickinson/setup-yq@latest
 
       - name: Get changed files
         id: changed-files
@@ -56,7 +56,7 @@ jobs:
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
               recipe_in_meta=$(yq 'package.name' $recipe/meta.yaml)
-              if [[ "$recipe" != "$recipe_in_meta" ]];
+              if [[ "$recipe" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe"
                 echo "Recipe name in meta.yaml is: $recipe_in_meta"
                 echo "They should be the same."

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -23,8 +23,8 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: Install yq - portable yaml processor
-        uses: uses: chrisdickinson/setup-yq@latest
+      - name: Install yq
+        uses: chrisdickinson/setup-yq@latest
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
+            yq --help
             for recipe in $changed; do
               noarch=$(yq e 'build.noarch' $recipe/meta.yaml)
               if [[ -z "$noarch" ]]; then
@@ -58,7 +59,6 @@ jobs:
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
             status=0
-            yq --help
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
               recipe_in_meta=$(yq e 'package.name' $recipe/meta.yaml)
               if [[ "$recipe" != "$recipe_in_meta" ]]; then

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -104,7 +104,7 @@ jobs:
               for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
                 recipe=$(basename $recipe_dir);
                 if [ -f $CONDA_PREFIX/conda-bld/$dir/$recipe-*.bz2 ]; then
-                  pkg=$(ls ${{ steps.find-build-dir.outputs.build_dir }}/$recipe-*.bz2 | head -n 1)
+                  pkg=$(ls $CONDA_PREFIX/conda-bld/$dir/$recipe-*.bz2 | head -n 1)
                   packages=$packages" "$pkg
                 fi
               done

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -48,7 +48,7 @@ jobs:
                 changed_no_noarch=" "+$recipe
               fi
             done
-            if [[ "${{ runner.os }}" == "macos-latest" ]]; then
+            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
               echo "Running on macos, setting changed to only those that are not noarch"
               changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
             fi

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -41,9 +41,8 @@ jobs:
         run: |
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
-            yq --help
             for recipe in $changed; do
-              noarch=$(yq e 'build.noarch' $recipe/meta.yaml)
+              noarch=$(yq r $recipe/meta.yaml 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" "+$recipe
@@ -51,7 +50,7 @@ jobs:
             done
             changed_noarch
             if [[ "${{ runner.os }}" == "macos-latest" ]]; then
-              changed=$(echo $changed_noarch | xargs) # xarg to remove any trailing spaces.
+              changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
             fi
             echo "::set-output name=changed_recipes::$changed"
 
@@ -60,7 +59,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(yq e 'package.name' $recipe/meta.yaml)
+              recipe_in_meta=$(yq r $recipe/meta.yaml 'package.name')
               if [[ "$recipe" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe"
                 echo "Recipe name in meta.yaml is: $recipe_in_meta"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -58,6 +58,7 @@ jobs:
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
             status=0
+            yq --help
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
               recipe_in_meta=$(yq e 'package.name' $recipe/meta.yaml)
               if [[ "$recipe" != "$recipe_in_meta" ]]; then

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -25,8 +25,10 @@ jobs:
 
       - name: Install yq
         uses: chrisdickinson/setup-yq@latest
-        with:
-          yq-version: 4.20.2
+        # This uses a rather old yq version, but setting the version doesn't work well
+        # note that this might break in the future if setup-yq uses a version > 4.18 of yq
+        #  with:
+        #  yq-version: 4.20.2
 
       - name: Get changed files
         id: changed-files
@@ -40,7 +42,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(yq 'build.noarch' $recipe/meta.yaml)
+              noarch=$(yq e 'build.noarch' $recipe/meta.yaml)
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" "+$recipe
@@ -57,7 +59,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(yq 'package.name' $recipe/meta.yaml)
+              recipe_in_meta=$(yq e 'package.name' $recipe/meta.yaml)
               if [[ "$recipe" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe"
                 echo "Recipe name in meta.yaml is: $recipe_in_meta"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -48,8 +48,8 @@ jobs:
                 changed_no_noarch=" "+$recipe
               fi
             done
-            changed_noarch
             if [[ "${{ runner.os }}" == "macos-latest" ]]; then
+              echo "Running on macos, setting changed to only those that are not noarch"
               changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
             fi
             echo "::set-output name=changed_recipes::$changed"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install yq
         uses: chrisdickinson/setup-yq@latest
+        with:
+          yq-version: 4.20.2
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -42,7 +42,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(yq r $recipe/meta.yaml 'build.noarch')
+              noarch=$(grep -v '^{' $recipe/meta.yaml | yq r 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" "+$recipe
@@ -59,7 +59,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(yq r $recipe/meta.yaml 'package.name')
+              recipe_in_meta=$(grep -v '^{' $recipe/meta.yaml | yq r 'package.name')
               if [[ "$recipe" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe"
                 echo "Recipe name in meta.yaml is: $recipe_in_meta"

--- a/recipes/atlas-web-sc-cli/meta.yaml
+++ b/recipes/atlas-web-sc-cli/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "11.2" %}
 
 package:
-  name: atlas-web-single-cell-cli
+  name: atlas-web-sc-cli
   version: {{ version }}
 
 source:
@@ -10,8 +10,9 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: false # [win32]
+  noarch: generic
 
 requirements:
   build:


### PR DESCRIPTION
This PR (second try):

- Fixes web-sc-cli for building (recipe title and directory name need to match) and sets to noarch
- Adds a CI check for the above
- Only does noarch on linux and not on mac on the CI
- Detects built packages more robustly