### PR TITLE
Bump atlas-bash-util

### DIFF
--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -45,7 +45,7 @@ jobs:
               noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
-                changed_no_noarch=" "+$recipe
+                changed_no_noarch=" $recipe"
               fi
             done
             if [[ "${{ matrix.os }}" == "macos-latest" ]]; then

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -45,7 +45,7 @@ jobs:
               noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
-                changed_no_noarch=" "+$recipe"
+                changed_no_noarch=" "+$recipe
               fi
             done
             if [[ "${{ matrix.os }}" == "macos-latest" ]]; then

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -45,7 +45,7 @@ jobs:
               noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
-                changed_no_noarch=" "+$recipe
+                changed_no_noarch=" "+$recipe"
               fi
             done
             if [[ "${{ matrix.os }}" == "macos-latest" ]]; then

--- a/recipes/atlas-bash-util/meta.yaml
+++ b/recipes/atlas-bash-util/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  noarch: generic
 
 requirements:
   build:

--- a/recipes/atlas-bash-util/meta.yaml
+++ b/recipes/atlas-bash-util/meta.yaml
@@ -15,7 +15,9 @@ requirements:
   build:
   host:
   run:
+    - coreutils
     - bash
+    - grep
 
 test:
   commands:

--- a/recipes/atlas-bash-util/meta.yaml
+++ b/recipes/atlas-bash-util/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.9" %}
+{% set version = "0.1.0" %}
 
 package:
   name: atlas-bash-util
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/atlas-bash-util/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: f6ff2f3afad0833228b0bb3f6e710d167b5d971e0613f2f751b5b1d033550101
+  sha256: 2db9cd2b46a580ebadd4e7673ffdfda4bd56872fb4b3fa836c0c37217d7640ba
 
 build:
   number: 0


### PR DESCRIPTION
This PR:

- Bumps the version of the atlas-bash-util package used. 
- Fixes an issue in MacOS CI (I think @pcm32 was having a python day with `" "+$recipe`).
- Sets the modified recipe to noarch, after adding a couple of dependencies for inter-platform consistency (e.g. the -P flag is absent on standard MacOS grep).