### PR TITLE
Add atlas-anndata recipe from pypi

### DIFF
--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -47,7 +47,6 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-            mamba-version: "*"
             miniconda-version: 'latest'
             activate-environment: test
             environment-file: .github/build-environment.yml
@@ -90,13 +89,13 @@ jobs:
       - name: Do a test build of modified recipes
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
-            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do mamba build $recipe; done
+            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do conda build $recipe; done
 
       - name: Derive built objects
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         id: find-built-objects
         run: |
-            subdirs=$(mamba config --show | yq '.subdirs' | sed 's/- //' | tr '\n' ' ')
+            subdirs=$(conda config --show | yq '.subdirs' | sed 's/- //' | tr '\n' ' ')
             packages=""
             for dir in $subdirs; do
               for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -58,7 +58,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
+              noarch=$(grep -v '{' $recipe | yq '.build.noarch')
               if [[ "$noarch" != 'null' ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -34,6 +34,26 @@ jobs:
         with:
             files: 'recipes'
 
+      - name: Cache conda
+        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if build-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('.github/build-environment.yml') }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
+        with:
+            miniconda-version: 'latest'
+            activate-environment: test
+            environment-file: .github/build-environment.yml
+            channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
+
       - name: List all modified recipes
         id: changed-recipes
         run: |
@@ -67,27 +87,6 @@ jobs:
               fi
             done
             exit $status
-
-
-      - name: Cache conda
-        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
-        uses: actions/cache@v2
-        env:
-          # Increase this value to reset cache if build-environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('.github/build-environment.yml') }}
-
-      - uses: conda-incubator/setup-miniconda@v2
-        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
-        with:
-            miniconda-version: 'latest'
-            activate-environment: test
-            environment-file: .github/build-environment.yml
-            channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 
       - name: Do a test build of modified recipes
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '{' $recipe | yq '.package.name')
+              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
               recipe_dir=$(echo $recipe | sed 's+recipes/++' )
               if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe_dir"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -84,6 +84,8 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         with:
+            auto-activate-base: true
+            activate-environment: ""
             environment-file: .github/build-environment.yml
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -59,7 +59,7 @@ jobs:
             changed_no_noarch=""
             for recipe in $changed; do
               noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
-              if [[ -z "$noarch" ]]; then
+              if [[ "$noarch" != 'null' ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"
               fi

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -58,7 +58,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '{' $recipe | yq '.build.noarch')
+              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
               if [[ "$noarch" != 'null' ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -84,8 +84,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         with:
-            auto-activate-base: true
-            activate-environment: ""
             environment-file: .github/build-environment.yml
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -59,7 +59,7 @@ jobs:
             changed_no_noarch=""
             for recipe in $changed; do
               noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
-              if [[ "$noarch" != 'null' ]]; then
+              if [[ "$noarch" == 'null' ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"
               fi

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false #  if one of the jobs in the matrix expansion fails, the rest of the jobs will be cancelled
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["self-hosted", "macos-latest"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         with:
+            miniconda-version: 'latest'
             activate-environment: test
             environment-file: .github/build-environment.yml
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         with:
+            activate-environment: test
             environment-file: .github/build-environment.yml
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -47,6 +47,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
+            mamba-version: "*"
             miniconda-version: 'latest'
             activate-environment: test
             environment-file: .github/build-environment.yml
@@ -89,13 +90,13 @@ jobs:
       - name: Do a test build of modified recipes
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
-            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do conda build $recipe; done
+            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do mamba build $recipe; done
 
       - name: Derive built objects
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         id: find-built-objects
         run: |
-            subdirs=$(conda config --show | yq '.subdirs' | sed 's/- //' | tr '\n' ' ')
+            subdirs=$(mamba config --show | yq '.subdirs' | sed 's/- //' | tr '\n' ' ')
             packages=""
             for dir in $subdirs; do
               for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -35,7 +35,6 @@ jobs:
             files: 'recipes'
 
       - name: Cache conda
-        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         uses: actions/cache@v2
         env:
           # Increase this value to reset cache if build-environment.yml has not changed
@@ -47,7 +46,6 @@ jobs:
             hashFiles('.github/build-environment.yml') }}
 
       - uses: conda-incubator/setup-miniconda@v2
-        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         with:
             miniconda-version: 'latest'
             activate-environment: test

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
+              recipe_in_meta=$(grep -v '{' $recipe | yq '.package.name')
               recipe_dir=$(echo $recipe | sed 's+recipes/++' )
               if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe_dir"

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -33,14 +33,9 @@ requirements:
     - jsonschema
     - peppy<0.31.2 
     - pillow>=8.3.2
-    - python<3.9
     - pyyaml
-    - scanpy-scripts >1.1.3
-    - setuptools-scm
     - snakemake
     - xlrd<2.0
-    - pip<19 
-    - cmake<3.20
 
 test:
   imports:

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "atlas-anndata" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/atlas_anndata-{{ version }}.tar.gz
+  sha256: 22913f6944946ea92325a57d2bd47e1ae56f2fd321b372bcd25e1aa205160694
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - click
+    - cmake <3.20
+    - jsonschema
+    - python
+    - pyyaml
+    - scanpy >1.1.2
+    - scanpy-scripts >1.1.3
+    - snakemake
+
+test:
+  imports:
+    - atlas_anndata
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: "https://github.com/ebi-gene-expression-group/atlas-anndata"
+  dev_url: "https://github.com/ebi-gene-expression-group/atlas-anndata"
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: "Tools for anndata generation/ consumption for Expression Atlas"
+
+extra:
+  recipe-maintainers:
+    - pcm32
+    - pinin4fjords

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -34,6 +34,9 @@ test:
     - atlas_anndata
   commands:
     - pip check
+    - make_bundle_from_anndata --help
+    - validate_anndata_with_config --help
+
   requires:
     - pip
 

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "atlas-anndata" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: atlas-anndata
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/atlas_anndata-{{ version }}.tar.gz
-  sha256: c3110472112f34016b6f8db4033e076d01ffad17e7a9df5ca3520b897bbe1408
+  sha256: 50f222d3b75636c21088aa2e086ea8e3c608cc0cea4030b7e5ce03a8cfd9969b
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
@@ -15,19 +15,19 @@ build:
 
 requirements:
   host:
-    - pip<19
     - python<3.9
-    - cmake <3.20
   run:
     - click
-    - pip<19
-    - cmake <3.20
     - jsonschema
     - python<3.9
     - pyyaml
-    - scanpy >1.1.2
-    - scanpy-scripts >1.1.3
+    - scanpy-scripts >1.1.5
     - snakemake
+    - peppy<0.31.2 
+    - pillow>=8.3.2
+    - xlrd<2.0
+    - cython
+    - setuptools-scm
 
 test:
   imports:

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -46,3 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - pinin4fjords
+    - pcm32

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "atlas-anndata" %}
-{% set version = "0.0.1" %}
+{% set version = "0.1.0" %}
 
 package:
   name: atlas-anndata
@@ -7,35 +7,27 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/atlas_anndata-{{ version }}.tar.gz
-  sha256: 22913f6944946ea92325a57d2bd47e1ae56f2fd321b372bcd25e1aa205160694
+  sha256: c3110472112f34016b6f8db4033e076d01ffad17e7a9df5ca3520b897bbe1408
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
-  build:
-    - python<3.9
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - cython
-    - pip<19 
-    - cmake<3.20
   host:
-    - pip
+    - pip<19
     - python<3.9
-    - pip<19 
-    - cmake<3.20
+    - cmake <3.20
   run:
     - click
-    - fa2
+    - pip<19
+    - cmake <3.20
     - jsonschema
-    - peppy<0.31.2 
-    - pillow>=8.3.2
+    - python<3.9
     - pyyaml
+    - scanpy >1.1.2
+    - scanpy-scripts >1.1.3
     - snakemake
-    - xlrd<2.0
 
 test:
   imports:
@@ -46,13 +38,11 @@ test:
     - pip
 
 about:
-  home: "https://github.com/ebi-gene-expression-group/atlas-anndata"
-  dev_url: "https://github.com/ebi-gene-expression-group/atlas-anndata"
+  home: https://github.com/ebi-gene-expression-group/atlas-anndata
+  summary: Functions for preparing annData files for experiment inclusion in Single cell Expression Atlas
   license: Apache-2.0
   license_file: LICENSE
-  summary: "Tools for anndata generation/ consumption for Expression Atlas"
 
 extra:
   recipe-maintainers:
-    - pcm32
     - pinin4fjords

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 22913f6944946ea92325a57d2bd47e1ae56f2fd321b372bcd25e1aa205160694
 
 build:
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "atlas-anndata" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.2" %}
 
 package:
   name: atlas-anndata
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/atlas_anndata-{{ version }}.tar.gz
-  sha256: 50f222d3b75636c21088aa2e086ea8e3c608cc0cea4030b7e5ce03a8cfd9969b
+  sha256: c2032f395a6d1558a71818f74bd09fbcba0a9277edda2e07a8e2142aa48aef06
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -15,18 +15,32 @@ build:
   number: 0
 
 requirements:
+  build:
+    - python<3.9
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cython
+    - pip<19 
+    - cmake<3.20
   host:
     - pip
-    - python
+    - python<3.9
+    - pip<19 
+    - cmake<3.20
   run:
     - click
-    - cmake <3.20
+    - fa2
     - jsonschema
-    - python
+    - peppy<0.31.2 
+    - pillow>=8.3.2
+    - python<3.9
     - pyyaml
-    - scanpy >1.1.2
     - scanpy-scripts >1.1.3
+    - setuptools-scm
     - snakemake
+    - xlrd<2.0
+    - pip<19 
+    - cmake<3.20
 
 test:
   imports:

--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.0.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: atlas-anndata
   version: {{ version }}
 
 source:


### PR DESCRIPTION
Just the thin Conda wrapper for https://pypi.org/project/atlas-anndata.

This is not currently 'noarch' since [grayskull](https://github.com/conda-incubator/grayskull) indicated I shouldn't do that when there are CLI scripts involved.

Also updated the CI to use self-hosted due to resource requirements. For some reason conda was being called before the conda bits and failed (see https://github.com/ebi-gene-expression-group/atlas-conda/pull/36/commits/19aa70d1f40283745e3b4de4ecd8f5215adf4d78), so I've make that setup unconditional and placed it early on.