### PR TITLE
Bump atlas-experiment-metadata

### DIFF
--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -23,13 +23,6 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: Install yq
-        uses: chrisdickinson/setup-yq@latest
-        # This uses a rather old yq version, but setting the version doesn't work well
-        # note that this might break in the future if setup-yq uses a version > 4.18 of yq
-        #  with:
-        #  yq-version: 4.20.2
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v9.3
@@ -38,11 +31,12 @@ jobs:
 
       - name: List all modified recipes
         id: changed-recipes
+        uses: mikefarah/yq@master
         run: |
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
+              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"
@@ -55,11 +49,12 @@ jobs:
             echo "::set-output name=changed_recipes::$changed"
 
       - name: Check directory matches recipe name
+        uses: mikefarah/yq@master
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq r - 'package.name')
+              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
               recipe_dir=$(echo $recipe | sed 's+recipes/++' )
               if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe_dir"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         id: find-built-objects
         run: |
-            subdirs=$(conda config --show | yq r - 'subdirs' | sed 's/- //' | tr '\n' ' ')
+            subdirs=$(conda config --show | yq '.subdirs' | sed 's/- //' | tr '\n' ' ')
             packages=""
             for dir in $subdirs; do
               for recipe_dir in ${{ steps.changed-recipes.outputs.changed_recipes }}; do

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -32,38 +32,40 @@ jobs:
       - name: List all modified recipes
         id: changed-recipes
         uses: mikefarah/yq@master
-        run: |
-            changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
-            changed_no_noarch=""
-            for recipe in $changed; do
-              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
-              if [[ -z "$noarch" ]]; then
-                # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
-                changed_no_noarch=" $recipe"
-              fi
-            done
-            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-              echo "Running on macos, setting changed to only those that are not noarch"
-              changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
-            fi
-            echo "::set-output name=changed_recipes::$changed"
+        with:
+            cmd: |
+                changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
+                changed_no_noarch=""
+                for recipe in $changed; do
+                  noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
+                  if [[ -z "$noarch" ]]; then
+                    # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
+                    changed_no_noarch=" $recipe"
+                  fi
+                done
+                if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+                  echo "Running on macos, setting changed to only those that are not noarch"
+                  changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
+                fi
+                echo "::set-output name=changed_recipes::$changed"
 
       - name: Check directory matches recipe name
-        uses: mikefarah/yq@master
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
-        run: |
-            status=0
-            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
-              recipe_dir=$(echo $recipe | sed 's+recipes/++' )
-              if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
-                echo "Recipe directory is        : $recipe_dir"
-                echo "Recipe name in meta.yaml is: $recipe_in_meta"
-                echo "They should be the same."
-                status=1
-              fi
-            done
-            exit $status
+        uses: mikefarah/yq@master
+        with:
+            cmd: |
+                status=0
+                for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
+                  recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
+                  recipe_dir=$(echo $recipe | sed 's+recipes/++' )
+                  if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
+                    echo "Recipe directory is        : $recipe_dir"
+                    echo "Recipe name in meta.yaml is: $recipe_in_meta"
+                    echo "They should be the same."
+                    status=1
+                  fi
+                done
+                exit $status
 
 
       - name: Cache conda

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -25,10 +25,8 @@ jobs:
 
       - name: Install yq
         uses: chrisdickinson/setup-yq@latest
-        # This uses a rather old yq version, but setting the version doesn't work well
-        # note that this might break in the future if setup-yq uses a version > 4.18 of yq
-        #  with:
-        #  yq-version: 4.20.2
+        with:
+          yq-version: v4.25.1
 
       - name: Get changed files
         id: changed-files
@@ -42,7 +40,7 @@ jobs:
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
+              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"
@@ -59,7 +57,7 @@ jobs:
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq r - 'package.name')
+              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
               recipe_dir=$(echo $recipe | sed 's+recipes/++' )
               if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe_dir"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -23,6 +23,13 @@ jobs:
         with:
             fetch-depth: 0
 
+      - name: Install yq
+        uses: chrisdickinson/setup-yq@latest
+        # This uses a rather old yq version, but setting the version doesn't work well
+        # note that this might break in the future if setup-yq uses a version > 4.18 of yq
+        #  with:
+        #  yq-version: 4.20.2
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v9.3
@@ -31,12 +38,11 @@ jobs:
 
       - name: List all modified recipes
         id: changed-recipes
-        uses: mikefarah/yq@master
         run: |
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
             changed_no_noarch=""
             for recipe in $changed; do
-              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
+              noarch=$(grep -v '{' $recipe/meta.yaml | yq r - 'build.noarch')
               if [[ -z "$noarch" ]]; then
                 # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
                 changed_no_noarch=" $recipe"
@@ -49,12 +55,11 @@ jobs:
             echo "::set-output name=changed_recipes::$changed"
 
       - name: Check directory matches recipe name
-        uses: mikefarah/yq@master
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         run: |
             status=0
             for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
+              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq r - 'package.name')
               recipe_dir=$(echo $recipe | sed 's+recipes/++' )
               if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
                 echo "Recipe directory is        : $recipe_dir"

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -32,40 +32,38 @@ jobs:
       - name: List all modified recipes
         id: changed-recipes
         uses: mikefarah/yq@master
-        with:
-            cmd: |
-                changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
-                changed_no_noarch=""
-                for recipe in $changed; do
-                  noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
-                  if [[ -z "$noarch" ]]; then
-                    # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
-                    changed_no_noarch=" $recipe"
-                  fi
-                done
-                if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-                  echo "Running on macos, setting changed to only those that are not noarch"
-                  changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
-                fi
-                echo "::set-output name=changed_recipes::$changed"
+        run: |
+            changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
+            changed_no_noarch=""
+            for recipe in $changed; do
+              noarch=$(grep -v '{' $recipe/meta.yaml | yq '.build.noarch')
+              if [[ -z "$noarch" ]]; then
+                # if noarch is empty, then this recipe is not no arch and should be built for mac and linux.
+                changed_no_noarch=" $recipe"
+              fi
+            done
+            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+              echo "Running on macos, setting changed to only those that are not noarch"
+              changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
+            fi
+            echo "::set-output name=changed_recipes::$changed"
 
       - name: Check directory matches recipe name
-        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
         uses: mikefarah/yq@master
-        with:
-            cmd: |
-                status=0
-                for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
-                  recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
-                  recipe_dir=$(echo $recipe | sed 's+recipes/++' )
-                  if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
-                    echo "Recipe directory is        : $recipe_dir"
-                    echo "Recipe name in meta.yaml is: $recipe_in_meta"
-                    echo "They should be the same."
-                    status=1
-                  fi
-                done
-                exit $status
+        if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
+        run: |
+            status=0
+            for recipe in ${{ steps.changed-recipes.outputs.changed_recipes }}; do
+              recipe_in_meta=$(grep -v '{' $recipe/meta.yaml | yq '.package.name')
+              recipe_dir=$(echo $recipe | sed 's+recipes/++' )
+              if [[ "$recipe_dir" != "$recipe_in_meta" ]]; then
+                echo "Recipe directory is        : $recipe_dir"
+                echo "Recipe name in meta.yaml is: $recipe_in_meta"
+                echo "They should be the same."
+                status=1
+              fi
+            done
+            exit $status
 
 
       - name: Cache conda

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.4" %}
+{% set version = "0.1.5" %}
 
 package:
   name: atlas-experiment-metadata
@@ -6,7 +6,7 @@ package:
 
 source:
     url: https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz
-    sha256: 27b3b4b582849608a5da8f995aed4bde64f6ccecd929da8c5acbb926a70a7bc9
+    sha256: a0fdfbda45a5e949f9d3edc499cea11bd9204007bdca10f67273ff5eff32b621
 
 build:
   number: 0

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -1,12 +1,12 @@
 {% set version = "0.1.5" %}
 
 package:
-  name: atlas-experiment-metadata
+  name: "atlas-experiment-metadata"
   version: {{ version }}
 
 source:
-    url: https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz
-    sha256: a0fdfbda45a5e949f9d3edc499cea11bd9204007bdca10f67273ff5eff32b621
+    url: "https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz"
+    sha256: "a0fdfbda45a5e949f9d3edc499cea11bd9204007bdca10f67273ff5eff32b621"
 
 build:
   number: 0
@@ -16,15 +16,15 @@ requirements:
   build:
   host:
   run:
-    - coreutils
-    - grep
-    - bash
-    - libgfortran
-    - perl-atlas-modules
-    - perl-dbd-pg
-    - r-optparse=1.6.0
-    - r-reshape2 
-    - r-data.table
+    - "coreutils"
+    - "grep"
+    - "bash"
+    - "libgfortran"
+    - "perl-atlas-modules"
+    - "perl-dbd-pg"
+    - "r-optparse=1.6.0"
+    - "r-reshape2" 
+    - "r-data.table"
 
 test:
   commands:
@@ -33,10 +33,10 @@ test:
     - unmelt_condensed.R --help
 
 about:
-  home: https://github.com/ebi-gene-expression-group/experiment_metadata
-  summary: Metadata handling scripts for Atlas
-  license: Apache-2.0
-  license_family: Apache
+  home: "https://github.com/ebi-gene-expression-group/experiment_metadata"
+  summary: "Metadata handling scripts for Atlas"
+  license: "Apache-2.0"
+  license_family: "Apache"
 
 extra:
   recipe-maintainers:

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -10,11 +10,14 @@ source:
 
 build:
   number: 0
+  noarch: generic
 
 requirements:
   build:
   host:
   run:
+    - coreutils
+    - grep
     - bash
     - libgfortran
     - perl-atlas-modules

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - grep
     - bash
     - libgfortran
-    - perl-atlas-modules
+    - perl-atlas-modules>=0.3.1
     - perl-dbd-pg
     - r-optparse=1.6.0
     - r-reshape2 

--- a/recipes/atlas-experiment-metadata/meta.yaml
+++ b/recipes/atlas-experiment-metadata/meta.yaml
@@ -1,12 +1,12 @@
 {% set version = "0.1.5" %}
 
 package:
-  name: "atlas-experiment-metadata"
+  name: atlas-experiment-metadata
   version: {{ version }}
 
 source:
-    url: "https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz"
-    sha256: "a0fdfbda45a5e949f9d3edc499cea11bd9204007bdca10f67273ff5eff32b621"
+    url: https://github.com/ebi-gene-expression-group/experiment_metadata/archive/v{{ version }}.tar.gz
+    sha256: a0fdfbda45a5e949f9d3edc499cea11bd9204007bdca10f67273ff5eff32b621
 
 build:
   number: 0
@@ -16,15 +16,15 @@ requirements:
   build:
   host:
   run:
-    - "coreutils"
-    - "grep"
-    - "bash"
-    - "libgfortran"
-    - "perl-atlas-modules"
-    - "perl-dbd-pg"
-    - "r-optparse=1.6.0"
-    - "r-reshape2" 
-    - "r-data.table"
+    - coreutils
+    - grep
+    - bash
+    - libgfortran
+    - perl-atlas-modules
+    - perl-dbd-pg
+    - r-optparse=1.6.0
+    - r-reshape2 
+    - r-data.table
 
 test:
   commands:
@@ -33,10 +33,10 @@ test:
     - unmelt_condensed.R --help
 
 about:
-  home: "https://github.com/ebi-gene-expression-group/experiment_metadata"
-  summary: "Metadata handling scripts for Atlas"
-  license: "Apache-2.0"
-  license_family: "Apache"
+  home: https://github.com/ebi-gene-expression-group/experiment_metadata
+  summary: Metadata handling scripts for Atlas
+  license: Apache-2.0
+  license_family: Apache
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
I need to use functionality in atlas-experiment-metdata which was added since the last release. So I made a new release in that package which I'm pointing to here. 

For some reason the perl-atlas-modules that came down was an old one from our own channel, so I've pinned it to make sure we get a recent version from Bioconda.

**Edit:** there's also a fix here on the CI usage