### PR TITLE
Add Mamba to atlas-anndata deps

### DIFF
--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -28,6 +28,7 @@ requirements:
     - xlrd<2.0
     - cython
     - setuptools-scm
+    - mamba
 
 test:
   imports:


### PR DESCRIPTION
Since it's currently [required](https://github.com/ebi-gene-expression-group/atlas-anndata/blob/b12e4c5dea4fe26d924a7fd12283369e8692f1b5/atlas_anndata/anndata_ops.py#L117) to run the snakemake workflow for MAGE-TAB injection.

Thanks to @YalanBi for reporting the lack.