### PR TITLE
Add snakemake pin for atlas-anndata recipe

### DIFF
--- a/recipes/atlas-anndata/meta.yaml
+++ b/recipes/atlas-anndata/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -22,7 +22,7 @@ requirements:
     - python<3.9
     - pyyaml
     - scanpy-scripts >1.1.5
-    - snakemake
+    - snakemake<7.8.0
     - peppy<0.31.2 
     - pillow>=8.3.2
     - xlrd<2.0


### PR DESCRIPTION
@YalanBi reported errors like:

```
Building DAG of jobs...
CreateCondaEnvironmentException:
Your conda installation is not configured to use strict channel priorities. This is however crucial for having robust and correct environments (for details, see https://conda-forge.org/docs/user/tipsandtricks.html). Please configure strict priorities by executing 'conda config --set channel_priority strict'.
...
```

When snakemake was executed from anndata_ops.py. Unfortunately, following the suggestion in the error created further errors like:

```
Encountered problems while solving:
  - package atlas-experiment-metadata-0.1.5-0 requires r-optparse 1.6.0.*, but none of the providers can be installed
```

There may be some cleanup to be done in the dependency tree, but for now we'll pin to a version of Snakemake not exhibiting the problem.