### PR TITLE
Bump atlas-web-sc-cli to latest version

### DIFF
--- a/recipes/atlas-web-sc-cli/meta.yaml
+++ b/recipes/atlas-web-sc-cli/meta.yaml
@@ -16,13 +16,13 @@ build:
 
 requirements:
   build:
-    - openjdk =11.0.0.0
-    - gradle =7.0.0
+    - openjdk=11
+    - gradle=7
   host:
   run:
     - bash
     - bats
-    - openjdk =11.0.0.0
+    - openjdk=11
 
 test:
   commands:

--- a/recipes/atlas-web-sc-cli/meta.yaml
+++ b/recipes/atlas-web-sc-cli/meta.yaml
@@ -16,13 +16,13 @@ build:
 
 requirements:
   build:
-    - openjdk >=11.0.0.0
-    - gradle >=7.0.0
+    - openjdk =11.0.0.0
+    - gradle =7.0.0
   host:
   run:
     - bash
     - bats
-    - openjdk >=11.0.0.0
+    - openjdk =11.0.0.0
 
 test:
   commands:

--- a/recipes/atlas-web-sc-cli/meta.yaml
+++ b/recipes/atlas-web-sc-cli/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "11.2" %}
+{% set version = "14.0.0-beta-cli" %}
 
 package:
   name: atlas-web-sc-cli

--- a/recipes/atlas-web-sc-cli/meta.yaml
+++ b/recipes/atlas-web-sc-cli/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "14.0.0-beta-cli" %}
+{% set version = "14.0.0" %}
 
 package:
   name: atlas-web-sc-cli

--- a/recipes/atlas-web-sc-cli/meta.yaml
+++ b/recipes/atlas-web-sc-cli/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "14.0.0" %}
+{% set version = "15.0.0" %}
 
 package:
   name: atlas-web-sc-cli


### PR DESCRIPTION
See https://github.com/ebi-gene-expression-group/atlas-web-single-cell/releases/tag/15.0.0-beta-cli.

I set OpenJDK and Gradle to major versions compatible with our project.