### PR TITLE
Debug failure of actions to upload to Anaconda

### DIFF
--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -107,7 +107,6 @@ jobs:
               done
             done
 
-            echo "::set-output name=built_objects::$(echo $packages | xargs)";
             echo "built_objects=$(echo $packages | xargs)"  >> $GITHUB_OUTPUT
 
       - name: Upload to Anaconda

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -2,10 +2,10 @@ name: Build conda packages upon pull request
 on:
   pull_request:
     branches:
-      - master
+      - master_test
   push:
     branches:
-      - master
+      - master_test
 
 jobs:
   get_changed_folders:  # job 1; # Get changed folders github action, https://github.com/marketplace/actions/get-changed-folders

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
         with:
             fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v9.3
         with:
             files: 'recipes'
 
@@ -53,7 +53,6 @@ jobs:
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 
       - name: List all modified recipes
-        if: ${{ steps.changed-files.outputs.all_modified_files != '' }}
         id: changed-recipes
         run: |
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')
@@ -69,7 +68,7 @@ jobs:
               echo "Running on macos, setting changed to only those that are not noarch"
               changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
             fi
-            echo "changed_recipes=$changed" >> $GITHUB_OUTPUT
+            echo "::set-output name=changed_recipes::$changed"
 
       - name: Check directory matches recipe name
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
@@ -108,7 +107,7 @@ jobs:
               done
             done
 
-            echo "built_objects=$(echo $packages | xargs)"  >> $GITHUB_OUTPUT
+            echo "::set-output name=built_objects::$(echo $packages | xargs)";
 
       - name: Upload to Anaconda
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changed-recipes.outputs.changed_recipes != '' }}

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -114,5 +114,5 @@ jobs:
         run: >-
             for built_package in ${{ steps.find-built-objects.outputs.built_objects }}; do
                 echo "Found built package $built_package to upload...";
-                anaconda -t ${{ secrets.ANACONDA_TOKEN_ATLAS_CONDA }} upload -u ebi-gene-expression-group $built_package;
+                # anaconda -t ${{ secrets.ANACONDA_TOKEN_ATLAS_CONDA }} upload -u ebi-gene-expression-group $built_package;
             done

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -110,7 +110,7 @@ jobs:
             echo "built_objects=$(echo $packages | xargs)"  >> $GITHUB_OUTPUT
 
       - name: Upload to Anaconda
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changed-recipes.outputs.changed_recipes != '' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master_test' && steps.changed-recipes.outputs.changed_recipes != '' }}
         run: >-
             for built_package in ${{ steps.find-built-objects.outputs.built_objects }}; do
                 echo "Found built package $built_package to upload...";

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -68,7 +68,7 @@ jobs:
               echo "Running on macos, setting changed to only those that are not noarch"
               changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
             fi
-            echo "::set-output name=changed_recipes::$changed"
+            echo "changed_recipes=$changed" >> $GITHUB_OUTPUT
 
       - name: Check directory matches recipe name
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
@@ -108,6 +108,7 @@ jobs:
             done
 
             echo "::set-output name=built_objects::$(echo $packages | xargs)";
+            echo "built_objects=$(echo $packages | xargs)"  >> $GITHUB_OUTPUT
 
       - name: Upload to Anaconda
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changed-recipes.outputs.changed_recipes != '' }}

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -53,6 +53,7 @@ jobs:
             channels: ebi-gene-expression-group,conda-forge,bioconda,defaults
 
       - name: List all modified recipes
+        if: ${{ steps.changed-files.outputs.all_modified_files != '' }}
         id: changed-recipes
         run: |
             changed=$(for file in ${{ steps.changed-files.outputs.all_modified_files }}; do dirname $file; done | sort | uniq | tr '\n' ' ')

--- a/.github/workflows/build_upon_pullrequest.yml
+++ b/.github/workflows/build_upon_pullrequest.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
             fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
               echo "Running on macos, setting changed to only those that are not noarch"
               changed=$(echo $changed_no_noarch | xargs) # xarg to remove any trailing spaces.
             fi
-            echo "::set-output name=changed_recipes::$changed"
+            echo "changed_recipes=$changed" >> $GITHUB_OUTPUT
 
       - name: Check directory matches recipe name
         if: ${{ steps.changed-recipes.outputs.changed_recipes != '' }}
@@ -107,7 +107,7 @@ jobs:
               done
             done
 
-            echo "::set-output name=built_objects::$(echo $packages | xargs)";
+            echo "built_objects=$(echo $packages | xargs)"  >> $GITHUB_OUTPUT
 
       - name: Upload to Anaconda
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.changed-recipes.outputs.changed_recipes != '' }}

--- a/recipes/atlas-bash-util/meta.yaml
+++ b/recipes/atlas-bash-util/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - coreutils
     - bash
     - grep
+    # - test line
 
 test:
   commands:


### PR DESCRIPTION
When merging a branch to master, `.github/workflows/build_upon_pullrequest.yml` does not execute step `Upload to Anaconda` despite meeting all conditions to run. Changes here aim to resolve this.